### PR TITLE
No space in generated zip

### DIFF
--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -331,7 +331,7 @@ gulp.task('clean:zip', function () {
 
 gulp.task('zip', function () {
     gulp.src([SETTINGS.build.app + '*', SETTINGS.build.app + '**/*'])
-        .pipe(gulpPlugins.zip('build-' + new Date() + '.zip'))
+        .pipe(gulpPlugins.zip('build-' + Date.now() + '.zip'))
         .pipe(gulp.dest('./zip/'));
 
     setTimeout(function () {


### PR DESCRIPTION
Making zips on windows does not currently work. With this edit (No spaces in generated filename), zip is now created successfully and it still uses date so sorting and ordering files by name will work.
